### PR TITLE
Use full url instead of compact one

### DIFF
--- a/src/Middleware/LivewireUrlsMiddleware.php
+++ b/src/Middleware/LivewireUrlsMiddleware.php
@@ -17,7 +17,7 @@ class LivewireUrlsMiddleware
         session()->put('livewire-urls.previous', session()->get('livewire-urls.current', null));
         session()->put('livewire-urls.previous-route', session()->get('livewire-urls.current-route', null));
 
-        session()->put('livewire-urls.current', $currentUrl = $request->url());
+        session()->put('livewire-urls.current', $currentUrl = $request->fullUrl());
         session()->put('livewire-urls.current-route', $currentRoute = $request->route()?->getName());
 
         session()->push('livewire-urls.history', $currentUrl);


### PR DESCRIPTION
Thanks for nice package 🎉

I think it better to store the full version of url, that include query string as well, instead of compact one. You know, we can easily handle the extra later. But missing of query string cause hard for some action that need it, like changing localization without losing the current url.