### PR TITLE
Allow usage of Livewire v3 beta

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require" : {
         "php" : "^8.0",
         "illuminate/contracts" : "^8.83|^9.0|^10.0",
-        "livewire/livewire" : "^2.10",
+        "livewire/livewire" : "^2.10|^3.0@beta",
         "spatie/laravel-package-tools" : "^1.9.2"
     },
     "require-dev" : {


### PR DESCRIPTION
In response to #20, this should allow for usage in the Livewire v3 beta.